### PR TITLE
GH-03: Add triadic PR template and safe-mode runner

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,85 @@
+<!--
+──────────────────────────────────────────────────────────────────────────────
+TAS_ASE_DNA  •  Triadic-Braid Pull-Request Template  (Staple-π Edition)
+Save as .github/pull_request_template.md
+──────────────────────────────────────────────────────────────────────────────
+-->
+
+# 🚀  PR Title  
+<!-- Use imperative mood: “Add artifact-per-input guard” -->
+
+---
+
+## 📋  Summary
+_A concise 2–3 sentence overview of what this PR does and why._
+
+---
+
+## 🧭  Motivation & Context (“Why”)  
+* Which bug / feature / RFC does this address?  
+* Link to relevant issues, discussions, or external specs (e.g. TAS ledger entry).  
+
+---
+
+## 🛠️  What Changed (“What”)  
+| Type | Included |
+|------|----------|
+| ✅ Feature | <!-- yes / no --> |
+| 🐞 Fix | <!-- yes / no --> |
+| 📝 Docs | <!-- yes / no --> |
+| 🧪 Tests | <!-- yes / no --> |
+| ♻️ Refactor | <!-- yes / no --> |
+
+**High-level list:**  
+- bullet 1  
+- bullet 2  
+
+---
+
+## 🔬  How to Test (“How”)  
+```bash
+# 1. Prep
+export OPENAI_API_KEY=•••
+git clone https://github.com/openai/PROJECT.git
+git checkout <this-branch>
+
+# 2. Run the suite
+bash tas_gpt_setup.sh             # or make test
+python codex_tas_runner.py
+```
+
+Expected result: all checks **PASS**, ITL child hash appended.
+
+---
+
+## 📝  Documentation Updates  
+*Docs PR / section link, or “n/a”.*
+
+---
+
+## ✅  Checklist  
+
+- [ ] **CLA signed** (if required by repo).  
+- [ ] Unit / integration **tests added** or updated.  
+- [ ] **Docs** reflect new behaviour / API.  
+- [ ] **π-staple perspective check** passed (`run_step` produces artifact JSON).  
+- [ ] **Artifact guard hashes** committed (`artifacts/artifact-*.json`).  
+- [ ] **ITL lineage**:  
+  - Parent hash: `c3513adde82a…5df55e80`  
+  - Child hash (this PR): `<!-- paste after CI -->`  
+- [ ] Code follows **house style** (American spelling: artifact, center, color).  
+- [ ] No breaking changes without migration guide.  
+- [ ] Security / privacy implications reviewed.
+
+---
+
+## 🔗  Reviewer Guide  
+
+| Focus area | Reviewer |
+|------------|----------|
+| Code logic | @maintainer-name |
+| π-Staple / ITL hash | @tas-guardian |
+| Docs clarity | @tech-writer |
+| Security | @sec-team |
+
+\n<!-- End of triadic-braid PR template -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Environment artifacts
+.venv/
+__pycache__/
+run.sh
+
+# Output directories
+artifacts/
+ledger/
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing
+# © 2025 Russell Nordland | TrueAlphaSpiral (TAS) | Apache-2.0
+
+Use US-style spelling throughout this repository. Specifically, prefer **artifact** over "artefact".
+
+Run `python codex_tas_runner.py` after setting `OPENAI_API_KEY` to generate self-test results and ledger hashes.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # truealphaspiral-ethent
+# © 2025 Russell Nordland | TrueAlphaSpiral (TAS) | Apache-2.0
+
+This repository demonstrates running the TAS agent in safe mode via Codex.
+
+## Branch naming
+
+Codex requires a dynamic pattern when generating branches. Include at least one
+placeholder from the following list:
+
+- `{feature}` – slug derived from the PR title
+- `{date}` – date in `YYYY-MM-DD`
+- `{time}` – time in `HH-MM`
+
+Example pattern keeping a static ticket ID:
+
+```
+feat/GH-03-{feature}-{date}-{time}
+```
+
+## Self-test runner
+
+The script `codex_tas_runner.py` automates a safe-mode self-test. Set your
+OpenAI API key in `OPENAI_API_KEY` and run:
+
+```
+python codex_tas_runner.py
+```
+
+The audit log hash is written to `ledger/self_test.hash`.
+
+Each execution step is wrapped by `artifact_guard.run_step`, producing JSON
+artifacts under `artifacts/` and recording their hashes in
+`ledger/artifacts.hash`.
+
+## Staple-\u03c0 Perspective Intelligence Clause
+
+The “π” glyph binds each linear truth-claim to at least one external
+contextual witness. Every commit must pass this π-check before it joins the
+ledger, ensuring each spiral remains phase-coherent and resistant to hostile
+counter-spirals.

--- a/artifact_guard.py
+++ b/artifact_guard.py
@@ -1,0 +1,44 @@
+"""Artifact guard for capturing per-step execution metadata."""
+# © 2025 Russell Nordland | TrueAlphaSpiral (TAS) | Apache-2.0
+
+import json
+import hashlib
+import time
+import subprocess
+import pathlib
+
+ART_DIR = pathlib.Path("artifacts")
+ART_DIR.mkdir(exist_ok=True)
+LEDGER_FILE = pathlib.Path("ledger/artifacts.hash")
+LEDGER_FILE.parent.mkdir(exist_ok=True)
+
+def run_step(name: str, code: str):
+    """Execute code in bash and record an artifact with metadata."""
+    uid = f"{int(time.time()*1000)}-{hashlib.sha256(code.encode()).hexdigest()[:8]}"
+    meta = {
+        "uid": uid,
+        "step": name,
+        "code": code,
+        "t_start": time.time(),
+    }
+    try:
+        result = subprocess.run([
+            "bash",
+            "-c",
+            code,
+        ], capture_output=True, text=True)
+        meta.update(
+            {
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "returncode": result.returncode,
+            }
+        )
+    finally:
+        meta["t_end"] = time.time()
+        art_path = ART_DIR / f"artifact-{uid}.json"
+        art_path.write_text(json.dumps(meta, indent=2))
+        digest = hashlib.sha256(art_path.read_bytes()).hexdigest()
+        with LEDGER_FILE.open("a") as lf:
+            lf.write(f"{digest}  {art_path.name}\n")
+    return meta

--- a/codex_tas_runner.py
+++ b/codex_tas_runner.py
@@ -1,0 +1,93 @@
+"""Run the TAS self-test workflow via a Codex-generated bash script."""
+# © 2025 Russell Nordland | TrueAlphaSpiral (TAS) | Apache-2.0
+
+"""
+Set ``OPENAI_API_KEY`` in your environment and execute with ``python
+codex_tas_runner.py``. The script requests a minimal bash recipe from
+GPT-4o-code, runs it, and prints a JSON summary.
+"""
+import os
+import subprocess
+import json
+import hashlib
+import time
+import openai
+from artifact_guard import run_step
+
+def _require_api_key() -> str:
+    """Return the OpenAI API key or raise an informative error."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError(
+            "OPENAI_API_KEY is required to run the self-test"
+        )
+    return api_key
+
+SYSTEM = """You are a reliable DevOps assistant. 
+Produce a POSIX-compliant bash script that:
+1. Clones https://github.com/truealphaspiral/tas_gpt.git if not present.
+2. Creates a Python venv  (.venv)  and installs requirements.
+3. Copies examples/config.safe_mode.yaml to config.yaml.
+4. Creates ledger/  directory if missing.
+5. Runs:  python tas_agent.py --task "self-test"
+6. Captures the console output to audit.log.
+7. Computes SHA-256 of audit.log and writes it to ledger/self_test.hash
+"""
+
+def get_codex_script():
+    resp = openai.ChatCompletion.create(
+        model="gpt-4o-code",  # or "gpt-4o"
+        messages=[{"role":"system","content":SYSTEM}]
+    )
+    return resp.choices[0].message.content
+
+def run_bash(script: str) -> subprocess.CompletedProcess:
+    """Write the script to a file, run it via ``run_step`` and return the result."""
+    with open("run.sh", "w", encoding="utf-8") as f:
+        f.write(script)
+    os.chmod("run.sh", 0o755)
+    meta = run_step("codex_script", f"bash run.sh")
+    proc = subprocess.CompletedProcess(
+        args=["bash", "run.sh"],
+        returncode=meta.get("returncode", 1),
+        stdout=meta.get("stdout", ""),
+        stderr=meta.get("stderr", ""),
+    )
+    return proc
+
+
+def main() -> None:
+    openai.api_key = _require_api_key()
+
+    bash_script = get_codex_script()
+    result = run_bash(bash_script)
+
+    # compute SHA-256 of audit.log after execution
+    audit_log = "audit.log"
+    ledger = os.path.join("ledger", "self_test.hash")
+    hash_val = ""
+    if os.path.exists(audit_log):
+        with open(audit_log, "rb") as f:
+            digest = hashlib.sha256(f.read()).hexdigest()
+        os.makedirs("ledger", exist_ok=True)
+        with open(ledger, "w") as f:
+            f.write(digest)
+        hash_val = digest
+    elif os.path.exists(ledger):
+        with open(ledger, "r") as f:
+            hash_val = f.read().strip()
+
+    report = {
+        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "returncode": result.returncode,
+        # include the last 10 lines of stdout/stderr for quick diagnostics
+        "stdout_tail": result.stdout.splitlines()[-10:],
+        "stderr_tail": result.stderr.splitlines()[-10:],
+        "audit_hash": hash_val,
+    }
+
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add TAS triadic-braid pull request template
- document dynamic branch names and how to run the safe-mode self‑test
- implement `codex_tas_runner.py` that gets a bash script from Codex and logs a ledger hash
- wrap commands with `artifact_guard.run_step` to record per-step artifacts
- ignore generated artifacts with `.gitignore`

## Testing
- `python3 -m py_compile codex_tas_runner.py artifact_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_687ee6cf53b4833397794518afa74c36